### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/cloudformation/FIXEngineApplication.json
+++ b/cloudformation/FIXEngineApplication.json
@@ -642,7 +642,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": 180
             },
             "Type": "AWS::Lambda::Function"
@@ -1630,7 +1630,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": 15
             },
             "Type": "AWS::Lambda::Function"
@@ -3091,7 +3091,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": 15
             },
             "Type": "AWS::Lambda::Function"
@@ -3496,7 +3496,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": 15
             },
             "Type": "AWS::Lambda::Function"
@@ -4395,7 +4395,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": 15
             },
             "Type": "AWS::Lambda::Function"
@@ -6490,7 +6490,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": 15
             },
             "Type": "AWS::Lambda::Function"

--- a/cloudformation/FIXEngineApplication.yml
+++ b/cloudformation/FIXEngineApplication.yml
@@ -410,7 +410,7 @@ Resources:
         - !Ref 'KMSKeyARN'
         - ''
       Role: !GetAtt 'AutomationDocumentStarterRole.Arn'
-      Runtime: python3.7
+      Runtime: python3.10
       Timeout: 180
     Type: AWS::Lambda::Function
   AutomationDocumentStarterLogGroup:
@@ -976,7 +976,7 @@ Resources:
         - !Ref 'KMSKeyARN'
         - ''
       Role: !GetAtt 'ECSImageRemoverRole.Arn'
-      Runtime: python3.7
+      Runtime: python3.10
       Timeout: 15
     Type: AWS::Lambda::Function
   ECSImageRemoverLogGroup:
@@ -1693,7 +1693,7 @@ Resources:
         - !Ref 'KMSKeyARN'
         - ''
       Role: !GetAtt 'GlobalAcceleratorInfoRetrieverRole.Arn'
-      Runtime: python3.7
+      Runtime: python3.10
       Timeout: 15
     Type: AWS::Lambda::Function
   GlobalAcceleratorInfoRetrieverLogGroup:
@@ -1928,7 +1928,7 @@ Resources:
         - !Ref 'KMSKeyARN'
         - ''
       Role: !GetAtt 'MSKClusterInfoRetrieverRole.Arn'
-      Runtime: python3.7
+      Runtime: python3.10
       Timeout: 15
     Type: AWS::Lambda::Function
   MSKClusterInfoRetrieverLogGroup:
@@ -2417,7 +2417,7 @@ Resources:
         - !Ref 'KMSKeyARN'
         - ''
       Role: !GetAtt 'MiscMethodsHandlerRole.Arn'
-      Runtime: python3.7
+      Runtime: python3.10
       Timeout: 15
     Type: AWS::Lambda::Function
   MiscMethodsHandlerLogGroup:
@@ -3589,7 +3589,7 @@ Resources:
         - !Ref 'KMSKeyARN'
         - ''
       Role: !GetAtt 'VPCPrefixListManagerRole.Arn'
-      Runtime: python3.7
+      Runtime: python3.10
       Timeout: 15
     Type: AWS::Lambda::Function
   VPCPrefixListManagerLogGroup:

--- a/cloudformation/FIXEngineVPCApplication.json
+++ b/cloudformation/FIXEngineVPCApplication.json
@@ -663,7 +663,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": 180
             },
             "Type": "AWS::Lambda::Function"
@@ -1654,7 +1654,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": 15
             },
             "Type": "AWS::Lambda::Function"
@@ -3388,7 +3388,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": 15
             },
             "Type": "AWS::Lambda::Function"
@@ -3831,7 +3831,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": 15
             },
             "Type": "AWS::Lambda::Function"
@@ -4735,7 +4735,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": 15
             },
             "Type": "AWS::Lambda::Function"
@@ -7215,7 +7215,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": 15
             },
             "Type": "AWS::Lambda::Function"

--- a/cloudformation/FIXEngineVPCApplication.yml
+++ b/cloudformation/FIXEngineVPCApplication.yml
@@ -418,7 +418,7 @@ Resources:
         - !Ref 'KMSKeyARN'
         - ''
       Role: !GetAtt 'AutomationDocumentStarterRole.Arn'
-      Runtime: python3.7
+      Runtime: python3.10
       Timeout: 180
     Type: AWS::Lambda::Function
   AutomationDocumentStarterLogGroup:
@@ -986,7 +986,7 @@ Resources:
         - !Ref 'KMSKeyARN'
         - ''
       Role: !GetAtt 'ECSImageRemoverRole.Arn'
-      Runtime: python3.7
+      Runtime: python3.10
       Timeout: 15
     Type: AWS::Lambda::Function
   ECSImageRemoverLogGroup:
@@ -1839,7 +1839,7 @@ Resources:
         - !Ref 'KMSKeyARN'
         - ''
       Role: !GetAtt 'GlobalAcceleratorInfoRetrieverRole.Arn'
-      Runtime: python3.7
+      Runtime: python3.10
       Timeout: 15
     Type: AWS::Lambda::Function
   GlobalAcceleratorInfoRetrieverLogGroup:
@@ -2093,7 +2093,7 @@ Resources:
         - !Ref 'KMSKeyARN'
         - ''
       Role: !GetAtt 'MSKClusterInfoRetrieverRole.Arn'
-      Runtime: python3.7
+      Runtime: python3.10
       Timeout: 15
     Type: AWS::Lambda::Function
   MSKClusterInfoRetrieverLogGroup:
@@ -2586,7 +2586,7 @@ Resources:
         - !Ref 'KMSKeyARN'
         - ''
       Role: !GetAtt 'MiscMethodsHandlerRole.Arn'
-      Runtime: python3.7
+      Runtime: python3.10
       Timeout: 15
     Type: AWS::Lambda::Function
   MiscMethodsHandlerLogGroup:
@@ -3946,7 +3946,7 @@ Resources:
         - !Ref 'KMSKeyARN'
         - ''
       Role: !GetAtt 'VPCPrefixListManagerRole.Arn'
-      Runtime: python3.7
+      Runtime: python3.10
       Timeout: 15
     Type: AWS::Lambda::Function
   VPCPrefixListManagerLogGroup:


### PR DESCRIPTION
CloudFormation templates in amazon-resilient-fix-engine-demo have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.